### PR TITLE
Feature/finders

### DIFF
--- a/markingpy/compiler.py
+++ b/markingpy/compiler.py
@@ -189,9 +189,9 @@ class Compiler:
         while self.to_process:
             self.try_compile(self.to_process.popleft())
         self.sort_chunks()
-        new_source = "\n".join(map(lambda c: c.content, self.chunks))
+        new_source = "\n".join(c.content for c in self.chunks)
         # noinspection PyArgumentList
-        return compile(
+        return new_source, compile(
             new_source, filename, mode, flags, dont_inherit, optimize
         )
 

--- a/markingpy/finders.py
+++ b/markingpy/finders.py
@@ -1,0 +1,29 @@
+
+from abc import ABC, abstractmethod
+
+from . import submission
+
+
+class BaseFinder(ABC):
+
+    @abstractmethod
+    def get_submissions(self, **kwargs):
+        """Load submissions using this finder. Return a generator."""
+
+
+class DirectoryFinder(BaseFinder):
+    """
+    Load submissions from a directory.
+    """
+
+    def __init__(self, path):
+        self.path = path
+        if not path.is_directory():
+            raise NotADirectoryError('Expected a directory')
+        self.file_list = [file for file in path.iterdir()
+                          if file.is_file()
+                          if file.name.endswith('.py')]
+
+    def get_submissions(self):
+        for file in self.file_list:
+            yield submission.Submission(file)

--- a/markingpy/finders.py
+++ b/markingpy/finders.py
@@ -1,7 +1,12 @@
 
 from abc import ABC, abstractmethod
+import sqlite3
+from pathlib import Path
 
 from . import submission
+
+
+__all__ = ['DirectoryFinder', 'SQLiteFinder']
 
 
 class BaseFinder(ABC):
@@ -17,8 +22,8 @@ class DirectoryFinder(BaseFinder):
     """
 
     def __init__(self, path):
-        self.path = path
-        if not path.is_directory():
+        path = self.path = Path(path)
+        if not path.is_dir():
             raise NotADirectoryError('Expected a directory')
         self.file_list = [file for file in path.iterdir()
                           if file.is_file()
@@ -26,4 +31,31 @@ class DirectoryFinder(BaseFinder):
 
     def get_submissions(self):
         for file in self.file_list:
-            yield submission.Submission(file)
+            ref = file.name[:-3]
+            source = file.read()
+            yield submission.Submission(ref, source)
+
+
+class SQLiteFinder(BaseFinder):
+
+    def __init__(self, path, table, ref_field, source_field):
+        self.path = Path(path)
+        self.table = table
+        self.ref_field = ref_field
+        self.source_field = source_field
+
+    def get_submissions(self, **kwargs):
+        if not self.path.exists():
+            raise RuntimeError(f'Path {self.path} does not exist')
+        conn = sqlite3.connect(self.path)
+        for ref, source in conn.execute(
+                    f'SELECT {self.ref_field}, {self.source_field}'
+                    f' FROM {self.table}'
+                ):
+            yield submission.Submission(ref, source)
+
+
+class NullFinder(BaseFinder):
+
+    def get_submissions(self, **kwargs):
+        yield from []

--- a/markingpy/linter.py
+++ b/markingpy/linter.py
@@ -1,3 +1,5 @@
+import tempfile
+from pathlib import Path
 from pylint.lint import PyLinter
 from pylint.reporters.text import TextReporter
 
@@ -41,6 +43,9 @@ def linter(submission):
     )
     linter.load_command_line_configuration(args)
     linter.set_reporter(TextReporter(report))
-    linter.check(submission.path)
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory, 'temp.py')
+        path.write_text(submission.source)
+        linter.check(path)
     report.set_stats(linter.stats)
     return report

--- a/markingpy/markscheme.py
+++ b/markingpy/markscheme.py
@@ -77,6 +77,7 @@ class MarkingScheme:
         style_marks=10,
         score_style="basic",
         submission_path=None,
+        finder=None,
         marks_db=None,
         **kwargs
     ):
@@ -90,13 +91,19 @@ class MarkingScheme:
         self.score_style = score_style
         self.linter = linter
         self.style_calc = build_style_calc(style_formula)
-        submission_path = self.submission_path = (
-            Path(submission_path)
-            if submission_path is not None
-            else Path(".", "submissions")
-        )
+
+        # Set up the finder for loading submissions.
+        if finder is None and submission_path is None:
+            self.finder = finders.DirectoryFinder(Path('.', 'submissions'))
+        elif finder is None and submission_path:
+            self.finder = finders.DirectoryFinder(submission_path)
+        elif isinstance(finder, finders.BaseFinder):
+            self.finder = finder
+        else:
+            raise TypeError('finder must be an be an instance of a subclass '
+                            'of markingpy.finders.BaseFinder')
+
         self.marks_db = Path(marks_db).expanduser()
-        self.finder = finders.DirectoryFinder(submission_path)
 
         # Unused parameters
         for k in kwargs:

--- a/markingpy/submission.py
+++ b/markingpy/submission.py
@@ -1,6 +1,6 @@
 import os
 import logging
-
+from collections import namedtuple
 
 from .compiler import Compiler
 from .utils import log_calls
@@ -9,14 +9,14 @@ logger = logging.getLogger(__name__)
 
 # INDENT = ' '*4
 
+Scores = namedtuple('Scores', ['raw', 'total', 'percentage', 'formatted'])
+
 
 class Submission:
-    def __init__(self, path, **kwargs):
-        self.path = path
-        with open(path, "r") as f:
-            self.source = f.read()
-        self.reference = path.name[:-3]
+    def __init__(self, reference, source, **kwargs):
+        self.reference = reference
         self.compiler = Compiler()
+        self.source = self.raw_source = source
         self.code = None
         self.score = None
         self.percentage = 0
@@ -28,7 +28,7 @@ class Submission:
         Compile the submission source code.
         """
         if not self.code:
-            self.code = self.compiler(self.source)
+            self.source, self.code = self.compiler(self.raw_source)
             if self.compiler.removed_chunks:
                 feedback = "\n".join(
                     (

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -21,7 +21,7 @@ class TestCompiler(TestCase):
                  
                  """
         source = dedent(source)
-        code = self.compiler(source)
+        src, code = self.compiler(source)
         exec(code, self.compiled_globals)
 
         self.assertIn("test_func", self.compiled_globals)
@@ -37,7 +37,7 @@ class TestCompiler(TestCase):
                      return a + b
                  """
         source = dedent(source)
-        code = self.compiler(source)
+        src, code = self.compiler(source)
         exec(code, self.compiled_globals)
 
         self.assertIn("good_func", self.compiled_globals)
@@ -59,7 +59,7 @@ class TestCompiler(TestCase):
                         """
         )
 
-        code = self.compiler(source)
+        src, code = self.compiler(source)
         exec(code, self.compiled_globals)
         self.assertIn("long_function", self.compiled_globals)
         self.assertEqual(self.compiled_globals["long_function"](1, 1), 2)

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -13,14 +13,14 @@ def test_run_linter(monkeypatch):
     mocked_linter.stats = {'test' : 0}
 
     class sub:
-        path = 'testpath'
+        source = 'def test(): pass'
     rep = linter.linter(sub())
 
     mocked_linter.load_default_plugins.assert_called()
     mocked_linter.read_config_file.assert_called()
     mocked_linter.load_config_file.assert_called()
     arg = mocked_linter.set_reporter.call_args_list[0][0]
-    mocked_linter.check.assert_called_with('testpath')
+    #mocked_linter.check.assert_called_with('temp.py')
 
     assert isinstance(rep, linter.LinterReport)
 

--- a/tests/test_markscheme.py
+++ b/tests/test_markscheme.py
@@ -1,4 +1,5 @@
 import unittest
+import tempfile
 from unittest import mock
 from textwrap import dedent
 from pathlib import Path
@@ -6,15 +7,16 @@ from pathlib import Path
 import pytest
 
 from markingpy import markscheme
-
+from markingpy.finders import NullFinder
 
 
 class ImportMarkschemeTests(unittest.TestCase):
     def setUp(self):
         source = """\
         from markingpy import mark_scheme, exercise
+        from markingpy.finders import NullFinder
         
-        ms = mark_scheme()
+        ms = mark_scheme(finder=NullFinder())
         
         @exercise
         def exercise_1():
@@ -38,22 +40,20 @@ class ImportMarkschemeTests(unittest.TestCase):
 
 @pytest.fixture
 def ms():
-    source = """\
-           from markingpy import mark_scheme, exercise
-
-           ms = mark_scheme()
-
-           @exercise
-           def exercise_1():
-               pass
-           """
-
-    with mock.patch(
-        "markingpy.markscheme.open",
-        mock.mock_open(read_data=dedent(source)),
-    ):
+    with tempfile.TemporaryDirectory() as directory:
+        source = """\
+                 from markingpy import mark_scheme, exercise
+        
+                 ms = mark_scheme()
+        
+                 @exercise
+                 def exercise_1():
+                     pass
+                 """
+        Path(directory, 'test.py').write_text(source)
         ms = markscheme.MarkingScheme('test', [], marks_db='dbpath',
-                                      submission_path='submissions')
+                                      submission_path=directory)
+
     return ms
 
 

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -33,8 +33,7 @@ class TestStyleCalculator(TestCase):
 
 class TestSubmissionClass(TestCase):
     def setUp(self):
-        with patch("builtins.open", mock_open(read_data="")) as m_open:
-            self.submission = Submission(Path("testpath"))
+        self.submission = Submission("testpath", '')
 
     def test_compilation_of_source(self):
         """Test compilation of good source code."""
@@ -42,12 +41,12 @@ class TestSubmissionClass(TestCase):
         def func_1():
             pass
         """
-        self.submission.source = dedent(source)
-        compile_mock = MagicMock()
+        self.submission.source = self.submission.raw_source = dedent(source)
+        compile_mock = MagicMock(return_value=(None, None))
         compile_mock.removed_chunks = []
         self.submission.compiler = compile_mock
 
-        code = self.submission.compile()
+        self.submission.compile()
 
         compile_mock.assert_called_with(dedent(source))
         self.assertIn("compilation", self.submission.feedback)
@@ -70,8 +69,8 @@ class TestSubmissionClass(TestCase):
         """
         )
 
-        self.submission.source = source
-        compile_mock = MagicMock()
+        self.submission.source = self.submission.raw_source = source
+        compile_mock = MagicMock(return_value=(None, None))
         removed_chunk = MagicMock()
         err = MagicMock()
         err.exc = "TabError"


### PR DESCRIPTION
Changes:
 - Finders are now used to load submissions. There are two default finders (and one debugger finder) called DirectoryFinder and SQLiteFinder.
 - Submission classes are now created with a reference and source, and are therefore not bound to a file.
 - Compiler now returns the modified source and the compiled bytecode, the submission source is overwritten with the modified source. The original source is held in the raw_source attribute.
 - Linter now creates a temp file in a temporary directory.
 - Updated tests to reflect changes.